### PR TITLE
TMB Mode version 3.4

### DIFF
--- a/emacs/LICENSE
+++ b/emacs/LICENSE
@@ -1,0 +1,13 @@
+This file is not part of GNU Emacs.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.

--- a/emacs/NEWS
+++ b/emacs/NEWS
@@ -1,0 +1,145 @@
+--------------------------------------------------------------------------------
+TMB Mode 3.4 (2018-01-14)
+--------------------------------------------------------------------------------
+o Added GUI toolbar for common tasks.
+
+o Bound f11 to `tmb-open'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 3.3 (2017-10-14)
+--------------------------------------------------------------------------------
+o Adjusted compiler flags to fix the combination precompile + debugging.
+
+o Adapted mini example to follow style of 'tmb_examples' and 'setupRStudio'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 3.2 (2016-11-16)
+--------------------------------------------------------------------------------
+o Added user variable `tmb-block-face'.
+
+o Added keywords "DATA_STRING", "SIMULATE", "PARALLEL_REGION", "rnorm", "rpois",
+  "rnbinom", "rnbinom2", "rgamma", and "simulate".
+
+o Improved `tmb-template-mini' so it asks for model name.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 3.1 (2015-11-10)
+--------------------------------------------------------------------------------
+o Added user function `tmb-toggle-window'.
+
+o Added internal function `tmb-split-window'.
+
+o Added user variable `tmb-window-right'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 3.0 (2015-10-01)
+--------------------------------------------------------------------------------
+o Added user functions `tmb-compile' and `tmb-multi-window'.
+
+o Added user variables `tmb-compile-args' and `tmb-debug-args'.
+
+o Renamed `tmb-run-debug' to `tmb-debug', `tmb-run-make' to `tmb-make', and
+  `tmb-r-command' to `tmb-compile-command'.
+
+o Removed `tmb-tool-bar-map'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 2.3 (2015-09-28)
+--------------------------------------------------------------------------------
+o Improved `tmb-toggle-nan-debug'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 2.2 (2015-09-22)
+--------------------------------------------------------------------------------
+o Added user function `tmb-toggle-nan-debug' and internal functions
+  `tmb-nan-off' and `tmb-nan-on'.
+
+o Added internal variables `tmb-menu', `tmb-mode-map', and `tmb-tool-bar-map'.
+
+o Added GUI menu and toolbar.
+
+o Renamed `tmb-toggle-function' to `tmb-toggle-show-function'.
+
+o Improved `tmb-template-mini'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 2.1 (2015-09-10)
+--------------------------------------------------------------------------------
+o Added internal function `tmb-windows-os-p'.
+
+o Improved `tmb-run-debug' and `tmb-template-mini'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 2.0 (2015-09-07)
+--------------------------------------------------------------------------------
+o Added user functions `tmb-run-debug', `tmb-scroll-down', `tmb-scroll-up',
+  `tmb-show-compilation', and `tmb-show-r'.
+
+o Renamed `tmb-open' to `tmb-open-any' and `tmb-run-r' to `tmb-run'.
+
+o Improved `tmb-open', `tmb-open-any', `tmb-run', `tmb-run-any', and
+  `tmb-template-mini'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 1.3 (2015-09-05)
+--------------------------------------------------------------------------------
+o Added user function `tmb-template-mini'.
+
+o Renamed `tmb-toggle-section' to `tmb-toggle-function'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 1.2 (2015-09-04)
+--------------------------------------------------------------------------------
+o Added user functions `tmb-clean', `tmb-for', `tmb-kill-process', `tmb-open',
+  `tmb-open-r', `tmb-run-any', `tmb-run-make', `tmb-run-r', and
+  `tmb-toggle-section'.
+
+o Added user variables `tmb-make-command' and `tmb-r-command'.
+
+o Disabled `abbrev-mode'.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 1.1 (2015-09-03)
+--------------------------------------------------------------------------------
+o Shortened list of recognized FUNCTIONS for maintainability.
+
+
+
+
+--------------------------------------------------------------------------------
+TMB Mode 1.0 (2015-09-01)
+--------------------------------------------------------------------------------
+o Created main function `tmb-mode', derived from `c++-mode'.

--- a/emacs/tmb.el
+++ b/emacs/tmb.el
@@ -1,27 +1,12 @@
 ;;; tmb.el --- Major mode for creating statistical models with TMB
 
-;; Copyright (C) 2015-2016 Arni Magnusson
+;; Copyright (C) 2015-2018 Arni Magnusson
 
 ;; Author:   Arni Magnusson
 ;; Keywords: languages
-;; URL:      http://www.hafro.is/~arnima/tmb.html
+;; URL:      https://github.com/kaskr/adcomp/blob/master/emacs
 
-(defconst tmb-mode-version "3.3" "TMB Mode version number.")
-
-;; This file is not part of GNU Emacs.
-
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-;;
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-;;
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+(defconst tmb-mode-version "3.4" "TMB Mode version number.")
 
 ;;; Commentary:
 ;;
@@ -78,9 +63,11 @@
 ;;   (set-face-attribute 'tmb-report-face    nil :foreground "dodgerblue")
 ;;   (set-face-attribute 'font-lock-variable-name-face nil
 ;;                       :foreground 'unspecified)
-;;   (local-set-key [f9]           'tmb-run )
-;;   (local-set-key [f10]          'tmb-open)
-;;   (local-set-key [down-mouse-3] 'imenu  ))
+;;   (local-set-key [f7]  'tmb-clean  )
+;;   (local-set-key [f8]  'tmb-compile)
+;;   (local-set-key [f9]  'tmb-run    )
+;;   (local-set-key [f10] 'tmb-debug  )
+;;   (local-set-key [down-mouse-3] 'imenu))
 ;; (add-hook 'tmb-mode-hook 'my-tmb-hook)
 ;;
 ;; Usage:
@@ -94,42 +81,7 @@
 
 ;;; History:
 ;;
-;; 14 Oct 2017  3.3  Tweaks by KK.
-;; 16 Nov 2016  3.2  Added user variable `tmb-block-face'. Added keywords
-;;                   "DATA_STRING", "SIMULATE", "PARALLEL_REGION", "rnorm",
-;;                   "rpois", "rnbinom", "rnbinom2", "rgamma", and "simulate".
-;;                   Improved `tmb-template-mini' so it asks for model name.
-;; 10 Nov 2015  3.1  Added user function `tmb-toggle-window', internal function
-;;                   `tmb-split-window', and user variable `tmb-window-right'.
-;; 01 Oct 2015  3.0  Added user functions `tmb-compile' and `tmb-multi-window'.
-;;                   Added user variables `tmb-compile-args' and
-;;                   `tmb-debug-args'. Renamed `tmb-run-debug' to `tmb-debug',
-;;                   `tmb-run-make' to `tmb-make', and `tmb-r-command' to
-;;                   `tmb-compile-command'. Removed `tmb-tool-bar-map'.
-;; 28 Sep 2015  2.3  Improved `tmb-toggle-nan-debug'.
-;; 22 Sep 2015  2.2  Added user function `tmb-toggle-nan-debug' and internal
-;;                   functions `tmb-nan-off' and `tmb-nan-on'. Added internal
-;;                   variables `tmb-menu', `tmb-mode-map', and
-;;                   `tmb-tool-bar-map'. Added GUI menu and toolbar. Renamed
-;;                   `tmb-toggle-function' to `tmb-toggle-show-function'.
-;;                   Improved `tmb-template-mini'.
-;; 10 Sep 2015  2.1  Added internal function `tmb-windows-os-p'. Improved
-;;                   `tmb-run-debug' and `tmb-template-mini'.
-;; 07 Sep 2015  2.0  Added user functions `tmb-run-debug', `tmb-scroll-down',
-;;                   `tmb-scroll-up', `tmb-show-compilation', and `tmb-show-r'.
-;;                   Renamed `tmb-open' to `tmb-open-any' and `tmb-run-r' to
-;;                   `tmb-run'. Improved `tmb-open', `tmb-open-any', `tmb-run',
-;;                   `tmb-run-any', and `tmb-template-mini'.
-;; 05 Sep 2015  1.3  Added user function `tmb-template-mini'. Renamed
-;;                   `tmb-toggle-section' to `tmb-toggle-function'.
-;; 04 Sep 2015  1.2  Added user functions `tmb-clean', `tmb-for',
-;;                   `tmb-kill-process', `tmb-open', `tmb-open-r',
-;;                   `tmb-run-any', `tmb-run-make', `tmb-run-r', and
-;;                   `tmb-toggle-section'. Added user variables
-;;                   `tmb-make-command' and `tmb-r-command'. Disabled
-;;                   `abbrev-mode'.
-;; 03 Sep 2015  1.1  Shortened list of recognized FUNCTIONS for maintainability.
-;; 01 Sep 2015  1.0  Created main function `tmb-mode', derived from `c++-mode'.
+;; See the NEWS file.
 
 ;;; Code:
 
@@ -251,19 +203,19 @@ The secondary window shows compilation and model runs, among other things."
 (nconc tmb-font-lock-keywords c++-font-lock-keywords)
 (defvar tmb-menu
   '("TMB"
-    ["View Script"         tmb-open            ]
-    ["View Compilation"    tmb-show-compilation]
-    ["View R Session"      tmb-show-r          ]
+    ["Stop"                tmb-kill-process    ]
+    ["Clean"               tmb-clean           ]
     "--"
     ["Compile"             tmb-compile         ]
     ["Run"                 tmb-run             ]
     ["Make"                tmb-make            ]
     "--"
-    ["Stop"                tmb-kill-process    ]
-    ["Clean"               tmb-clean           ]
-    "--"
     ["Debug"               tmb-debug           ]
     ["Toggle NaN Debug"    tmb-toggle-nan-debug]
+    "--"
+    ["View Script"         tmb-open            ]
+    ["View Compilation"    tmb-show-compilation]
+    ["View R Session"      tmb-show-r          ]
     "--"
     ["Mini Template"       tmb-template-mini   ]
     ["Multi-Window Layout" tmb-multi-window    ]
@@ -278,6 +230,7 @@ The secondary window shows compilation and model runs, among other things."
   ;; Available C-c C-     e   ij          u   yz
   (let ((map (make-sparse-keymap)))
     (easy-menu-define nil map nil tmb-menu)
+    (define-key map [f11]               'tmb-open                )
     (define-key map [f12]               'tmb-template-mini       )
     (define-key map [?\C-c C-backspace] 'tmb-clean               )
     (define-key map [M-up]              'tmb-scroll-up           )
@@ -301,7 +254,14 @@ The secondary window shows compilation and model runs, among other things."
     (define-key map [?\C-c ?\C-t]       'tmb-toggle-window       )
     (define-key map [?\C-c ?\C-v]       'tmb-run                 )
     (define-key map [?\C-c ?\C-w]       'tmb-multi-window        )
-    (define-key map [?\C-\M-v]          'ignore                  )
+    map))
+(defvar tmb-tool-bar-map
+  (let ((map (tool-bar-make-keymap)))
+    (tool-bar-local-item "separator" 'ignore nil map :help "" :enable nil)
+    (tool-bar-local-item "disconnect" 'tmb-clean 'Clean map)
+    (tool-bar-local-item "connect" 'tmb-compile 'Compile map)
+    (tool-bar-local-item "jump-to" 'tmb-run 'Run map)
+    (tool-bar-local-item "describe" 'tmb-debug 'Debug map)
     map))
 
 ;; 4  User functions
@@ -359,7 +319,7 @@ The R session stays alive if it was running when this function was called."
   "Show TMB Mode version number." (interactive)
   (message "TMB Mode version %s" tmb-mode-version))
 (defun tmb-open ()
-  "Open R script with same filename prefix as current buffer." (interactive)
+  "Open R script with same filename prefix in other window." (interactive)
   (tmb-open-any "R"))
 (defun tmb-open-any (ext)
   "Open file with extension EXT in other window." (interactive "sExtension: ")
@@ -521,9 +481,9 @@ can be helpful.\n
 While staying in the TMB window, navigate the secondary window with
 \\<tmb-mode-map>\
 \\[beginning-of-buffer-other-window], \\[scroll-other-window-down], \
-\\[tmb-scroll-up] (scroll home, page up, line up), and
+\\[tmb-scroll-up] (home, page up, line up), and
 \\[end-of-buffer-other-window], \\[scroll-other-window], \
-\\[tmb-scroll-down] (scroll end, page down, line down).
+\\[tmb-scroll-down] (end, page down, line down).
 This is particularly efficient for navigating error messages listed
 in the compilation buffer.\n
 \\{tmb-mode-map}"
@@ -531,6 +491,9 @@ in the compilation buffer.\n
   (modify-syntax-entry ?_ "w" tmb-mode-syntax-table)
   (set (make-local-variable 'font-lock-defaults)
        '(tmb-font-lock-keywords nil nil))
+  (set (make-local-variable 'tool-bar-map) tmb-tool-bar-map)
   (setq compilation-scroll-output 'first-error))
 
 (provide 'tmb)
+
+;;; tmb.el ends here


### PR DESCRIPTION
Host TMB Mode version 3.4 (temporarily) on github.com/admb-project.
This is to support the build process for AD Studio.
Once TMB Mode 3.4 has been merged into kaskr/adcomp, the adstudio-components.bat can be edited accordingly.